### PR TITLE
lower version bound on cc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -322,7 +322,7 @@ libc = { version = "0.2.69", default-features = false }
 
 # Keep this in sync with `[dependencies]` in pregenerate_asm/Cargo.toml.
 [build-dependencies]
-cc = { version = "1.0.52", default-features = false }
+cc = { version = "1.0.41", default-features = false }
 
 [features]
 # These features are documented in the top-level module's documentation.


### PR DESCRIPTION
fix dependency conflict with secp256k1, which is used by tendermint-rs master version